### PR TITLE
Add Jaeger Thrift exporter

### DIFF
--- a/spring-cloud-sleuth-otel-autoconfigure/pom.xml
+++ b/spring-cloud-sleuth-otel-autoconfigure/pom.xml
@@ -237,6 +237,11 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-exporter-jaeger-thrift</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-otlp</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelExporterConfiguration.java
+++ b/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelExporterConfiguration.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -75,6 +77,18 @@ class OtelExporterConfiguration {
 			Long timeout = properties.getJaeger().getTimeout();
 			if (timeout != null) {
 				builder.setTimeout(timeout, TimeUnit.MILLISECONDS);
+			}
+			return builder.build();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		JaegerThriftSpanExporter otelJaegerThriftSpanExporter(OtelExporterProperties properties) {
+			JaegerThriftSpanExporterBuilder builder = JaegerThriftSpanExporter.builder();
+
+			String endpoint = properties.getJaeger().getEndpoint();
+			if (StringUtils.hasText(endpoint)) {
+				builder.setEndpoint(endpoint);
 			}
 			return builder.build();
 		}

--- a/spring-cloud-sleuth-otel-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelExporterConfigurationTests.java
+++ b/spring-cloud-sleuth-otel-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelExporterConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.autoconfig.otel;
 
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,15 @@ class OtelExporterConfigurationTests {
 	}
 
 	@Test
+	void should_pick_jaeger_thrift_exporter_when_present_on_the_classpath() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withClassLoader(new FilteredClassLoader("io.opentelemetry.exporter.otlp"))
+				.withUserConfiguration(OtelExporterConfiguration.class);
+
+		contextRunner.run(context -> BDDAssertions.then(context).hasSingleBean(JaegerThriftSpanExporter.class));
+	}
+
+	@Test
 	void should_pick_otlp_exporter_when_present_on_the_classpath() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 				.withClassLoader(new FilteredClassLoader("io.opentelemetry.exporter.jaeger"))
@@ -50,7 +60,8 @@ class OtelExporterConfigurationTests {
 				.withUserConfiguration(OtelExporterConfiguration.class);
 
 		contextRunner.run(context -> BDDAssertions.then(context).hasSingleBean(OtlpGrpcSpanExporter.class)
-				.hasSingleBean(JaegerGrpcSpanExporter.class));
+				.hasSingleBean(JaegerGrpcSpanExporter.class)
+				.hasSingleBean(JaegerThriftSpanExporter.class));
 	}
 
 }


### PR DESCRIPTION
This adds the Jaeger Thrift exporter which uses HTTP instead of gRPC.

It works just as other exporters and can be overriden bu the end user by explicitly specifying a JaegerThriftSpanExporter.