### PR TITLE
Minor cleanup

### DIFF
--- a/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelBridgeConfiguration.java
+++ b/spring-cloud-sleuth-otel-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/otel/OtelBridgeConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.sleuth.autoconfig.otel;
 import java.util.regex.Pattern;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.propagation.ContextPropagators;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -43,6 +44,7 @@ import org.springframework.cloud.sleuth.instrument.web.HttpClientSampler;
 import org.springframework.cloud.sleuth.instrument.web.HttpServerRequestParser;
 import org.springframework.cloud.sleuth.instrument.web.HttpServerResponseParser;
 import org.springframework.cloud.sleuth.instrument.web.SkipPatternProvider;
+import org.springframework.cloud.sleuth.otel.bridge.EventPublishingContextWrapper;
 import org.springframework.cloud.sleuth.otel.bridge.OtelBaggageManager;
 import org.springframework.cloud.sleuth.otel.bridge.OtelCurrentTraceContext;
 import org.springframework.cloud.sleuth.otel.bridge.OtelHttpClientHandler;
@@ -78,11 +80,12 @@ class OtelBridgeConfiguration {
 				sleuthBaggageProperties.getRemoteFields(), sleuthBaggageProperties.getTagFields(), publisher));
 	}
 
-	// Both CurrentTraceContext & ContextStorage wrapper
+	// Both CurrentTraceContext & application of a ContextStorage wrapper
 	@Bean
 	@ConditionalOnMissingBean
 	OtelCurrentTraceContext otelCurrentTraceContext(ApplicationEventPublisher publisher) {
-		return new OtelCurrentTraceContext(publisher);
+		ContextStorage.addWrapper(new EventPublishingContextWrapper(publisher));
+		return new OtelCurrentTraceContext();
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/EventPublishingContextWrapper.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/EventPublishingContextWrapper.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.otel.bridge;
+
+import java.util.function.Function;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.Nullable;
+
+public final class EventPublishingContextWrapper implements Function<ContextStorage, ContextStorage> {
+
+	private final ApplicationEventPublisher publisher;
+
+	public EventPublishingContextWrapper(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	@Override
+	public ContextStorage apply(ContextStorage contextStorage) {
+		return new ContextStorage() {
+			@Override
+			public io.opentelemetry.context.Scope attach(Context context) {
+				Context currentContext = Context.current();
+				io.opentelemetry.context.Scope scope = contextStorage.attach(context);
+				if (scope == io.opentelemetry.context.Scope.noop()) {
+					return scope;
+				}
+				publisher.publishEvent(new ScopeAttachedEvent(this, context));
+				return () -> {
+					scope.close();
+					publisher.publishEvent(new ScopeClosedEvent(this));
+					publisher.publishEvent(new ScopeRestoredEvent(this, currentContext));
+				};
+			}
+
+			@Override
+			public Context current() {
+				return contextStorage.current();
+			}
+		};
+	}
+
+	public static class ScopeAttachedEvent extends ApplicationEvent {
+
+		/**
+		 * Context corresponding to the attached scope. Might be {@code null}.
+		 */
+		final Context context;
+
+		/**
+		 * Create a new {@code ApplicationEvent}.
+		 * @param source the object on which the event initially occurred or with which
+		 * the event is associated (never {@code null})
+		 * @param context corresponding otel context
+		 */
+		public ScopeAttachedEvent(Object source, @Nullable Context context) {
+			super(source);
+			this.context = context;
+		}
+
+		Span getSpan() {
+			return Span.fromContextOrNull(context);
+		}
+
+		Baggage getBaggage() {
+			return Baggage.fromContextOrNull(context);
+		}
+
+		@Override
+		public String toString() {
+			return "ScopeAttached{context: [span: " + getSpan() + "] [baggage: " + getBaggage() + "]}";
+		}
+
+	}
+
+	public static class ScopeClosedEvent extends ApplicationEvent {
+
+		/**
+		 * Create a new {@code ApplicationEvent}.
+		 * @param source the object on which the event initially occurred or with which
+		 * the event is associated (never {@code null})
+		 */
+		public ScopeClosedEvent(Object source) {
+			super(source);
+		}
+
+	}
+
+	public static class ScopeRestoredEvent extends ApplicationEvent {
+
+		/**
+		 * {@link Context} corresponding to the scope being restored. Might be
+		 * {@code null}.
+		 */
+		final Context context;
+
+		/**
+		 * Create a new {@code ApplicationEvent}.
+		 * @param source the object on which the event initially occurred or with which
+		 * the event is associated (never {@code null})
+		 * @param context corresponding otel context
+		 */
+		public ScopeRestoredEvent(Object source, @Nullable Context context) {
+			super(source);
+			this.context = context;
+		}
+
+		Span getSpan() {
+			return Span.fromContextOrNull(context);
+		}
+
+		Baggage getBaggage() {
+			return Baggage.fromContextOrNull(context);
+		}
+
+		@Override
+		public String toString() {
+			return "ScopeRestored{context: [span: " + getSpan() + "] [baggage: " + getBaggage() + "]}";
+		}
+
+	}
+
+}

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelTracer.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelTracer.java
@@ -72,7 +72,7 @@ public class OtelTracer implements Tracer {
 		if (span == null) {
 			// remove any existing span/baggage data from the current state of anything
 			// that might be holding on to it.
-			this.publisher.publishEvent(new OtelCurrentTraceContext.ScopeClosed(this));
+			this.publisher.publishEvent(new EventPublishingContextWrapper.ScopeClosedEvent(this));
 			return io.opentelemetry.api.trace.Span.getInvalid();
 		}
 		return ((OtelSpan) span).delegate;

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/Slf4jApplicationListener.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/Slf4jApplicationListener.java
@@ -28,7 +28,7 @@ public class Slf4jApplicationListener implements ApplicationListener<Application
 
 	private static final Log log = LogFactory.getLog(Slf4jApplicationListener.class);
 
-	private void onScopeAttached(OtelCurrentTraceContext.ScopeAttached event) {
+	private void onScopeAttached(EventPublishingContextWrapper.ScopeAttachedEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope changed event [" + event + "]");
 		}
@@ -39,7 +39,7 @@ public class Slf4jApplicationListener implements ApplicationListener<Application
 		}
 	}
 
-	private void onScopeRestored(OtelCurrentTraceContext.ScopeRestored event) {
+	private void onScopeRestored(EventPublishingContextWrapper.ScopeRestoredEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope restored event [" + event + "]");
 		}
@@ -50,7 +50,7 @@ public class Slf4jApplicationListener implements ApplicationListener<Application
 		}
 	}
 
-	private void onScopeClosed(OtelCurrentTraceContext.ScopeClosed event) {
+	private void onScopeClosed(EventPublishingContextWrapper.ScopeClosedEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope closed event [" + event + "]");
 		}
@@ -60,14 +60,14 @@ public class Slf4jApplicationListener implements ApplicationListener<Application
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
-		if (event instanceof OtelCurrentTraceContext.ScopeAttached) {
-			onScopeAttached((OtelCurrentTraceContext.ScopeAttached) event);
+		if (event instanceof EventPublishingContextWrapper.ScopeAttachedEvent) {
+			onScopeAttached((EventPublishingContextWrapper.ScopeAttachedEvent) event);
 		}
-		else if (event instanceof OtelCurrentTraceContext.ScopeClosed) {
-			onScopeClosed((OtelCurrentTraceContext.ScopeClosed) event);
+		else if (event instanceof EventPublishingContextWrapper.ScopeClosedEvent) {
+			onScopeClosed((EventPublishingContextWrapper.ScopeClosedEvent) event);
 		}
-		else if (event instanceof OtelCurrentTraceContext.ScopeRestored) {
-			onScopeRestored((OtelCurrentTraceContext.ScopeRestored) event);
+		else if (event instanceof EventPublishingContextWrapper.ScopeRestoredEvent) {
+			onScopeRestored((EventPublishingContextWrapper.ScopeRestoredEvent) event);
 		}
 	}
 

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/Slf4jBaggageApplicationListener.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/Slf4jBaggageApplicationListener.java
@@ -41,7 +41,7 @@ public class Slf4jBaggageApplicationListener implements ApplicationListener<Appl
 		this.correlationFields = correlationFields;
 	}
 
-	private void onScopeAttached(OtelCurrentTraceContext.ScopeAttached event) {
+	private void onScopeAttached(EventPublishingContextWrapper.ScopeAttachedEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope attached event [" + event + "]");
 		}
@@ -50,7 +50,7 @@ public class Slf4jBaggageApplicationListener implements ApplicationListener<Appl
 		}
 	}
 
-	private void onScopeRestored(OtelCurrentTraceContext.ScopeRestored event) {
+	private void onScopeRestored(EventPublishingContextWrapper.ScopeRestoredEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope restored event [" + event + "]");
 		}
@@ -67,7 +67,7 @@ public class Slf4jBaggageApplicationListener implements ApplicationListener<Appl
 		});
 	}
 
-	private void onScopeClosed(OtelCurrentTraceContext.ScopeClosed event) {
+	private void onScopeClosed(EventPublishingContextWrapper.ScopeClosedEvent event) {
 		if (log.isTraceEnabled()) {
 			log.trace("Got scope closed event [" + event + "]");
 		}
@@ -76,14 +76,14 @@ public class Slf4jBaggageApplicationListener implements ApplicationListener<Appl
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
-		if (event instanceof OtelCurrentTraceContext.ScopeAttached) {
-			onScopeAttached((OtelCurrentTraceContext.ScopeAttached) event);
+		if (event instanceof EventPublishingContextWrapper.ScopeAttachedEvent) {
+			onScopeAttached((EventPublishingContextWrapper.ScopeAttachedEvent) event);
 		}
-		else if (event instanceof OtelCurrentTraceContext.ScopeClosed) {
-			onScopeClosed((OtelCurrentTraceContext.ScopeClosed) event);
+		else if (event instanceof EventPublishingContextWrapper.ScopeClosedEvent) {
+			onScopeClosed((EventPublishingContextWrapper.ScopeClosedEvent) event);
 		}
-		else if (event instanceof OtelCurrentTraceContext.ScopeRestored) {
-			onScopeRestored((OtelCurrentTraceContext.ScopeRestored) event);
+		else if (event instanceof EventPublishingContextWrapper.ScopeRestoredEvent) {
+			onScopeRestored((EventPublishingContextWrapper.ScopeRestoredEvent) event);
 		}
 	}
 

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/otel/OtelTestTracing.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/otel/OtelTestTracing.java
@@ -61,7 +61,7 @@ public class OtelTestTracing implements TracerAware, TestTracingAware, TestTraci
 
 	HttpRequestParser clientRequestParser;
 
-	CurrentTraceContext currentTraceContext = OtelAccessor.currentTraceContext(publisher());
+	CurrentTraceContext currentTraceContext = OtelAccessor.currentTraceContext();
 
 	protected ContextPropagators contextPropagators() {
 		return ContextPropagators.create(B3Propagator.injectingMultiHeaders());
@@ -115,7 +115,7 @@ public class OtelTestTracing implements TracerAware, TestTracingAware, TestTraci
 
 	@Override
 	public CurrentTraceContext currentTraceContext() {
-		return OtelAccessor.currentTraceContext(publisher());
+		return OtelAccessor.currentTraceContext();
 	}
 
 	@Override

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelAccessor.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelAccessor.java
@@ -53,13 +53,8 @@ public final class OtelAccessor {
 		return openTelemetry.getTracer("org.springframework.cloud.sleuth");
 	}
 
-	public static CurrentTraceContext currentTraceContext(ApplicationEventPublisher publisher) {
-		return new OtelCurrentTraceContext(publisher);
-	}
-
 	public static CurrentTraceContext currentTraceContext() {
-		return currentTraceContext(event -> {
-		});
+		return new OtelCurrentTraceContext();
 	}
 
 	public static TraceContext traceContext(SpanContext spanContext) {

--- a/tests/otel/spring-cloud-sleuth-instrumentation-baggage-tests/pom.xml
+++ b/tests/otel/spring-cloud-sleuth-instrumentation-baggage-tests/pom.xml
@@ -104,6 +104,10 @@
 			<!-- Kotlin... -->
 			<version>4.8.0</version>
 		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-sdk-testing</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
A few things in here:
1) Used the otel testing artifact to make the baggage tests work correctly and assert that there were proper events.
2) Extracted the context wrapper into a top-level class, so it could be re-used by tests
3) misc. minor cleanups in the rest of the project