### PR TITLE
doc: fix twice W3C

### DIFF
--- a/docs/src/main/asciidoc/documentation-overview.adoc
+++ b/docs/src/main/asciidoc/documentation-overview.adoc
@@ -28,7 +28,7 @@ They provide solutions to the most common questions.
 If you are starting out with {project-full-name}, try one of the https://spring.io/guides[guides].
 * Ask a question.
 We monitor https://stackoverflow.com[stackoverflow.com] for questions tagged with https://stackoverflow.com/tags/{project-name}[`{project-name}`].
-* Report bugs with {project-full-name} at https://github.com/spring-cloud/{project-name}/issues.
+* Report bugs with {project-full-name} at https://github.com/spring-cloud-incubator/{project-name}/issues.
 * Chat with us at http://https://gitter.im/spring-cloud/{project-name}[{project-full-name} Gitter]
 
 NOTE: All of {project-full-name} is open source, including the documentation.

--- a/docs/src/main/asciidoc/howto.adoc
+++ b/docs/src/main/asciidoc/howto.adoc
@@ -568,7 +568,7 @@ spring.zipkin.sender.type: activemq
 To use the provided defaults you can set the `spring.sleuth.propagation.type` property.
 The value can be a list in which case you will propagate more tracing headers.
 
-For OpenTelemetry we support `AWS`, `B3`, `JAEGER`, `W3C`, `OT_TRACER` and `W3C` propagation types.
+For OpenTelemetry we support `AWS`, `B3`, `JAEGER`, `OT_TRACER` and `W3C` propagation types.
 
 If you want to provide a custom propagation mechanism set the `spring.sleuth.propagation.type` property to `CUSTOM` and implement your own bean (`Propagation.Factory` for Brave and `TextMapPropagator` for OpenTelemetry).
 Below you can find the examples:


### PR DESCRIPTION
There's twice `W3C` in the same sentence.