### PR TITLE
Allow injecting HttpServerAttributesExtractor and allow override of toURI method 

### DIFF
--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelHttpServerHandler.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/OtelHttpServerHandler.java
@@ -23,6 +23,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import org.apache.commons.logging.Log;
@@ -60,12 +61,12 @@ public class OtelHttpServerHandler implements HttpServerHandler {
 	private final Instrumenter<HttpServerRequest, HttpServerResponse> instrumenter;
 
 	public OtelHttpServerHandler(OpenTelemetry openTelemetry, HttpRequestParser httpServerRequestParser,
-			HttpResponseParser httpServerResponseParser, SkipPatternProvider skipPatternProvider) {
+			HttpResponseParser httpServerResponseParser, SkipPatternProvider skipPatternProvider,
+			HttpServerAttributesExtractor<HttpServerRequest, HttpServerResponse> httpAttributesExtractor) {
 		this.httpServerRequestParser = httpServerRequestParser;
 		this.httpServerResponseParser = httpServerResponseParser;
 		this.pattern = skipPatternProvider.skipPattern();
 
-		SpringHttpServerAttributesExtractor httpAttributesExtractor = new SpringHttpServerAttributesExtractor();
 		this.instrumenter = Instrumenter
 				.<HttpServerRequest, HttpServerResponse>newBuilder(openTelemetry, "org.springframework.cloud.sleuth",
 						HttpSpanNameExtractor.create(httpAttributesExtractor))
@@ -73,6 +74,12 @@ public class OtelHttpServerHandler implements HttpServerHandler {
 				.addAttributesExtractor(new HttpRequestNetServerAttributesExtractor())
 				.addAttributesExtractor(httpAttributesExtractor).addAttributesExtractor(new PathAttributeExtractor())
 				.newServerInstrumenter(getGetter());
+	}
+
+	public OtelHttpServerHandler(OpenTelemetry openTelemetry, HttpRequestParser httpServerRequestParser,
+			HttpResponseParser httpServerResponseParser, SkipPatternProvider skipPatternProvider) {
+		this(openTelemetry, httpServerRequestParser, httpServerResponseParser, skipPatternProvider,
+				new SpringHttpServerAttributesExtractor());
 	}
 
 	@Override

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/SpringHttpClientAttributesExtractor.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/SpringHttpClientAttributesExtractor.java
@@ -30,7 +30,8 @@ import org.springframework.lang.Nullable;
  *
  * @author Nikita Salnikov-Tarnovski
  */
-class SpringHttpClientAttributesExtractor extends HttpClientAttributesExtractor<HttpClientRequest, HttpClientResponse> {
+public class SpringHttpClientAttributesExtractor
+		extends HttpClientAttributesExtractor<HttpClientRequest, HttpClientResponse> {
 
 	@Nullable
 	@Override

--- a/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/SpringHttpServerAttributesExtractor.java
+++ b/spring-cloud-sleuth-otel/src/main/java/org/springframework/cloud/sleuth/otel/bridge/SpringHttpServerAttributesExtractor.java
@@ -31,7 +31,8 @@ import org.springframework.lang.Nullable;
  *
  * @author Nikita Salnikov-Tarnovski
  */
-class SpringHttpServerAttributesExtractor extends HttpServerAttributesExtractor<HttpServerRequest, HttpServerResponse> {
+public class SpringHttpServerAttributesExtractor
+		extends HttpServerAttributesExtractor<HttpServerRequest, HttpServerResponse> {
 
 	@Nullable
 	@Override
@@ -49,7 +50,7 @@ class SpringHttpServerAttributesExtractor extends HttpServerAttributesExtractor<
 		return uri.getPath() + queryPart(uri);
 	}
 
-	private URI toUri(HttpServerRequest request) {
+	protected URI toUri(HttpServerRequest request) {
 		String url = request.url();
 		return url == null ? null : URI.create(url);
 	}


### PR DESCRIPTION
This will allow me to inject My own implementation of SpringHttpServerAttributesExtractor toURI method will be overridden by following so illegal char will NOT cause parsing issue on OTL implementation.



```
    @Override
    protected URI toUri(HttpServerRequest request) {
        try {
            return URI.create(request.url());
        }catch (IllegalArgumentException e){
            // not able to parse it URL.
        }
        String url = request.url();
        for(String c:ILLEGAL_CHARS){
            url = url.replace(c,"");
        }
        return URI.create(url);
    }

```

